### PR TITLE
Fix for filters passed as ID values

### DIFF
--- a/bwdata.py
+++ b/bwdata.py
@@ -761,6 +761,11 @@ class BWData:
         return self.project.get(endpoint="queries/"+str(query_id)+"/"+"date-range")
 
     def _fill_params(self, name, startDate, data):
+        try:
+            name = int(name)
+        except ValueError:
+            pass
+
         name_list = [name] if isinstance(name, (str, int)) else name
         id_list = []
 

--- a/bwresources.py
+++ b/bwresources.py
@@ -379,10 +379,14 @@ class BWQueries(BWResource, bwdata.BWData):
         return mention["mention"]
 
     def _name_to_id(self, attribute, setting):
-
         if isinstance(setting, int):
-            # already in ID form
             return setting
+
+        if isinstance(setting, list):
+            try:
+                return [int(i) for i in setting]
+            except ValueError:
+                pass
 
         elif attribute in ["category", "xcategory"]:
             # setting is a dictionary with one key-value pair, so this loop iterates only once

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name='bwapi',
 
-    version='2.1.4',
+    version='2.2.0',
 
     description='A software development kit for the Brandwatch API',
 


### PR DESCRIPTION
Addition to a previous update which allowed project & query values to be passed as ID's and parsed by the sdk accordingly. This allows for the same with filter values