### PR TITLE
Submit the password as the body of the request

### DIFF
--- a/bwproject.py
+++ b/bwproject.py
@@ -74,7 +74,7 @@ class BWUser:
                 "grant_type": grant_type,
                 "client_id": client_id
             },
-            body={
+            data={
                 "password": password
             }).json()
         if "access_token" in token:

--- a/bwproject.py
+++ b/bwproject.py
@@ -71,9 +71,11 @@ class BWUser:
             self.apiurl + self.oauthpath,
             params={
                 "username": username,
-                "password": password,
                 "grant_type": grant_type,
                 "client_id": client_id
+            },
+            body={
+                "password": password
             }).json()
         if "access_token" in token:
             return username, token["access_token"]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name='bwapi',
 
-    version='3.0.0',
+    version='3.1.0',
 
     description='A software development kit for the Brandwatch API',
 


### PR DESCRIPTION
This relates to #48 and #49 and the associated discussion.

This passes the password as the body of the request.
The difference can be demonstrated as follows:

    requests.post('...', params={"one": 1, "two": 2})

    ➜ nc -l 9999
    POST /?one=1&two=2 HTTP/1.1
    Host: localhost:9999
    User-Agent: python-requests/2.18.4
    Accept-Encoding: gzip, deflate
    Accept: */*
    Connection: keep-alive
    Content-Length: 0

Compared to

    requests.post('...', params={"one": 1}, body={"two": 2})

    ➜ nc -l 9999
    POST /?one=1 HTTP/1.1
    Host: localhost:9999
    User-Agent: python-requests/2.18.4
    Accept-Encoding: gzip, deflate
    Accept: */*
    Connection: keep-alive
    Content-Length: 5
    Content-Type: application/x-www-form-urlencoded

    two=2