### PR TITLE
Fix _name_to_id method for query group

### DIFF
--- a/bwresources.py
+++ b/bwresources.py
@@ -588,20 +588,20 @@ class BWGroups(BWResource, bwdata.BWData):
             except ValueError:
                 pass
 
-        elif attribute in ["category", "xcategory"]:
+        if attribute in ["category", "xcategory"]:
             # setting is a dictionary with one key-value pair, so this loop iterates only once
             # but is necessary to extract the values in the dictionary
             ids = []
             for category in setting:
                 parent = category
                 children = setting[category]
-            for child in children:
-                ids.append(self.categories.ids[parent]["children"][child])
+                for child in children:
+                    ids.append(self.categories.ids[parent]["children"][child])
             return ids
 
         elif attribute in ["parentCategory", "xparentCategory", "parentCategories", "categories"]:
-            #plural included for get_charts syntax
-            #note: parentCategories and categories params will be ignored for everything but chart calls
+            # plural included for get_charts syntax
+            # note: parentCategories and categories params will be ignored for everything but chart calls
             if not isinstance(setting, list):
                 setting = [setting]
             ids = []
@@ -610,7 +610,7 @@ class BWGroups(BWResource, bwdata.BWData):
             return ids
 
         elif attribute in ["tag", "xtag", "tags"]:
-            #plural included for get_charts syntax
+            # plural included for get_charts syntax
             if not isinstance(setting, list):
                 setting = [setting]
             ids = []


### PR DESCRIPTION
Same change as in PR #42:
https://github.com/BrandwatchLtd/api_sdk/commit/4d6d256b4d544d8a2d8d44ad9f4b462a339650b6
_name_to_id fix for BWGroups class