### PR TITLE
Overwrite children for existing categories

### DIFF
--- a/bwresources.py
+++ b/bwresources.py
@@ -1032,7 +1032,7 @@ class BWCategories():
                     if child not in existing_children:
                         new_children.append(child)
 
-                if new_children:
+                if new_children or overwrite_children:
                     if not overwrite_children:
                         # add the new children to the existing children
                         for child in self.ids[name]["children"]:


### PR DESCRIPTION
When overwrite_children is set to true, we may need to make a put request even when there's no new child category in data. So that we can re-order existing child categories or remove unnecessary ones.