### PR TITLE
Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 
 matrix:
   include:
-    - python: 3.0
-    - python: 3.1
-    - python: 3.2
     - python: 3.3
     - python: 3.4
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: python
+
+matrix:
+  include:
+    - python: 3.0
+    - python: 3.1
+    - python: 3.2
+    - python: 3.3
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: true
+    - python: 3.7-dev
+      dist: xenial
+      sudo: true
+    - python: 3.8-dev
+      dist: xenial
+      sudo: true
+
+install:
+  - python setup.py install
+
+script:
+  - python setup.py test
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/hamishmorgan/api_sdk.svg?branch=master)](https://travis-ci.org/hamishmorgan/api_sdk)
+
 # Brandwatch API SDK
 
 ## Introduction

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,6 @@ setup(
 
     py_modules=['bwproject', 'bwresources', 'bwdata', 'filters'],
 
-    install_requires=['requests'],
+    install_requires=['requests']
 
 )

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,11 @@ setup(
         'License :: OSI Approved :: MIT License',
 
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7'
     ],
 
     py_modules=['bwproject', 'bwresources', 'bwdata', 'filters'],

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
 
     py_modules=['bwproject', 'bwresources', 'bwdata', 'filters'],
 
-    install_requires=['requests']
+    install_requires=['requests'],
 
 )


### PR DESCRIPTION
Adds support for Travis CI, so we can build and test on each PR merge.

I removed support for Python 3.2 from setup.py because requests doesn't actually support it.

I added support for Python 3.6 and 3.7 because they do appear to work.