### PR TITLE
Authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 matrix:
   include:
-    - python: 3.3
     - python: 3.4
     - python: 3.5
     - python: 3.6

--- a/DEMO.ipynb
+++ b/DEMO.ipynb
@@ -99,9 +99,40 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Start by loading a project\n",
+    "The first time, you have to authenticated with Brandwatch by entering your username and password, to get an access token. The access token is stored in a credentials file tokens.txt in your home directory. Once you've authenticated your access token will be read from that file so you won't need your password any more. and you won't need to enter a password. \n",
     "\n",
-    "The first time, you have to enter your password to get an access token. The token is stored in a file tokens.txt.  In the future, your token will come from that file and you won't need to enter a password. (Alternately, you can explicitly pass in token as a parameter and skip the password altogether.)"
+    "You can authenticate from command line using the provided script `authenticate.py`:\n",
+    "\n",
+    "```\n",
+    "$ ./authenticate.py\n",
+    "Please enter your Brandwatch credentials below\n",
+    "Username: example@example\n",
+    "Password:\n",
+    "Authenticating user: example@example\n",
+    "Writing access token for user: example@example\n",
+    "Writing access token for user: example@example\n",
+    "Success! Access token: 00000000-0000-0000-0000-000000000000\n",
+    "```\n",
+    "\n",
+    "Alternatively, you can call the `authenticate(...)` function directly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from authenticate import authenticate\n",
+    "\n",
+    "authenticate(username=\"user@example.com\", password=\"YOUR_PASSWORD\", credentials_path=\"tokens.txt\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now you have authenticated you can load your project:"
    ]
   },
   {
@@ -113,19 +144,9 @@
    "outputs": [],
    "source": [
     "YOUR_ACCOUNT = your_account\n",
-    "YOUR_PASSWORD = your_password\n",
-    "YOUR_PROJECT = your_project"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "project = BWProject(username=YOUR_ACCOUNT, password=YOUR_PASSWORD, project=YOUR_PROJECT)"
+    "YOUR_PROJECT = your_project\n",
+    "\n",
+    "project = BWProject(username=YOUR_ACCOUNT, project=YOUR_PROJECT)"
    ]
   },
   {

--- a/authenticate.py
+++ b/authenticate.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+from getpass import getpass
+import logging
+from pathlib import Path
+
+import credentials
+from bwproject import BWUser
+
+import argparse
+
+
+def authenticate(username: str, password: str, credentials_path=None) -> BWUser:
+    """""
+    Authenticate the given username and password pair, storing the access token in the credentials file.
+
+    :param username: Brandwatch account usernames
+    :param password: Brandwatch account password
+    :param credentials_path: Path to where credentials should be stored
+    :return: An authenticated BWUser object
+    """
+    return BWUser(username=username, password=password, token_path=credentials_path)
+
+
+def main():
+    logger = logging.getLogger("bwapi")
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("%(levelname)s: %(message)s", "%H:%M:%S")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+    parser = argparse.ArgumentParser(description="Logging to Brandwatch and retrieve and access token.")
+
+    parser.add_argument("--store", "-s", type=Path, metavar="PATH", default=credentials.DEFAULT_CREDENTIALS_PATH,
+                        help="Path to where access tokens are stored. (Default: {})".format(
+                            credentials.DEFAULT_CREDENTIALS_PATH))
+
+    parser.add_argument("--username", "-u", type=str, help="Brandwatch username (probably your email address).")
+    parser.add_argument("--password", "-p", type=str, help="Brandwatch password.")
+
+    args = parser.parse_args()
+
+    if args.username is None or args.password is None:
+        print("Please enter your Brandwatch credentials below")
+        if args.username is None:
+            args.username = input("Username: ")
+        if args.password is None:
+            args.password = getpass("Password: ")
+
+    try:
+        print("Authenticating user: {}".format(args.username))
+        user = authenticate(args.username, args.password, credentials_path=args.store)
+        print("Success! Access token: {}".format(user.token))
+    except KeyError as e:
+        print(e)
+
+
+if __name__ == "__main__":
+    main()

--- a/authenticate.py
+++ b/authenticate.py
@@ -11,7 +11,7 @@ from bwproject import BWUser
 import argparse
 
 
-def authenticate(username: str, password: str, credentials_path=None) -> BWUser:
+def authenticate(username, password, credentials_path=None):
     """""
     Authenticate the given username and password pair, storing the access token in the credentials file.
 

--- a/authenticate.py
+++ b/authenticate.py
@@ -12,7 +12,7 @@ import argparse
 
 
 def authenticate(username, password, credentials_path=None):
-    """""
+    """
     Authenticate the given username and password pair, storing the access token in the credentials file.
 
     :param username: Brandwatch account usernames

--- a/authenticate.py
+++ b/authenticate.py
@@ -31,11 +31,13 @@ def main():
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 
-    parser = argparse.ArgumentParser(description="Logging to Brandwatch and retrieve and access token.")
+    parser = argparse.ArgumentParser(
+        description="Logging to Brandwatch and retrieve and access token.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
 
     parser.add_argument("--store", "-s", type=Path, metavar="PATH", default=credentials.DEFAULT_CREDENTIALS_PATH,
-                        help="Path to where access tokens are stored. (Default: {})".format(
-                            credentials.DEFAULT_CREDENTIALS_PATH))
+                        help="Path to where access tokens are stored.")
 
     parser.add_argument("--username", "-u", type=str, help="Brandwatch username (probably your email address).")
     parser.add_argument("--password", "-p", type=str, help="Brandwatch password.")

--- a/credentials.py
+++ b/credentials.py
@@ -19,13 +19,15 @@ class CredentialsStore:
 
     _credentials_path: Path
 
-    def __init__(self, credentials_path=DEFAULT_CREDENTIALS_PATH):
+    def __init__(self, credentials_path=None):
         """
         Create a new CredentialsStore
 
         :param credentials_path: Path to the credentials file
         """
-        self._credentials_path = credentials_path
+        if credentials_path is None:
+            credentials_path = DEFAULT_CREDENTIALS_PATH
+        self._credentials_path = Path(credentials_path)
 
     def __getitem__(self, username: str) -> str:
         """ Get self[username] """

--- a/credentials.py
+++ b/credentials.py
@@ -4,9 +4,10 @@ credentials contains the CredentialsStore class, which responsible for persistin
 """
 
 import logging
+import os
 from pathlib import Path
 
-DEFAULT_CREDENTIALS_PATH = Path.home() / '.bwapi' / "credentials.txt"
+DEFAULT_CREDENTIALS_PATH = Path(os.path.expanduser('~')) / '.bwapi' / "credentials.txt"
 
 logger = logging.getLogger("bwapi")
 

--- a/credentials.py
+++ b/credentials.py
@@ -5,7 +5,6 @@ credentials contains the CredentialsStore class, which responsible for persistin
 
 import logging
 from pathlib import Path
-from typing import Mapping
 
 DEFAULT_CREDENTIALS_PATH = Path.home() / '.bwapi' / "credentials.txt"
 
@@ -17,8 +16,6 @@ class CredentialsStore:
     CredentialsStore is responsible for persisting access tokens to disk.
     """
 
-    _credentials_path: Path
-
     def __init__(self, credentials_path=None):
         """
         Create a new CredentialsStore
@@ -29,12 +26,12 @@ class CredentialsStore:
             credentials_path = DEFAULT_CREDENTIALS_PATH
         self._credentials_path = Path(credentials_path)
 
-    def __getitem__(self, username: str) -> str:
+    def __getitem__(self, username):
         """ Get self[username] """
         user_tokens = self._read()
         return user_tokens[username.lower()]
 
-    def __setitem__(self, username: str, token: str):
+    def __setitem__(self, username, token):
         """ Set self[username] to access token. """
         credentials = self._read()
         if username.lower() in credentials:
@@ -63,13 +60,13 @@ class CredentialsStore:
     def __len__(self):
         return len(self._read())
 
-    def _write(self, credentials: Mapping[str, str]):
+    def _write(self, credentials):
         self._ensure_file_exists()
         with open(self._credentials_path, 'w') as token_file:
             contents = "\n".join(["\t".join(item) for item in credentials.items()])
             token_file.write(contents)
 
-    def _read(self) -> Mapping[str, str]:
+    def _read(self):
         self._ensure_file_exists()
         with open(self._credentials_path) as token_file:
             credentials = dict()

--- a/credentials.py
+++ b/credentials.py
@@ -41,9 +41,9 @@ class CredentialsStore:
             if credentials[username.lower()] == token:
                 return
             else:
-                logger.debug("Overwriting access token for user: {}", username)
+                logger.info("Overwriting access token for %s in %s", username, self._credentials_path)
         else:
-            logger.debug("Writing access token for user: {}", username)
+            logger.info("Writing access token for user: %s", username)
         credentials[username.lower()] = token
         self._write(credentials)
 
@@ -51,7 +51,7 @@ class CredentialsStore:
         """ Delete self[username]. """
         credentials = self._read()
         if username.lower() in credentials:
-            logger.debug("Deleting access token for user: {}", username)
+            logger.info("Deleting access token for user: %s", username)
             del credentials[username.lower()]
             self._write(credentials)
 
@@ -77,7 +77,7 @@ class CredentialsStore:
                 try:
                     user, token = line.split()
                 except ValueError:
-                    logger.warning("Ignoring corrupted credentials line: \"{}\"", line)
+                    logger.warning("Ignoring corrupted credentials line: \"%s\"", line)
                     pass
                 credentials[user.lower()] = token
             return credentials
@@ -85,10 +85,10 @@ class CredentialsStore:
     def _ensure_file_exists(self):
         self._ensure_dir_exists()
         if not self._credentials_path.exists():
-            logger.debug("Creating credentials store: {}", self._credentials_path)
+            logger.debug("Creating credentials store: %s", self._credentials_path)
             self._credentials_path.touch(mode=0o600)
 
     def _ensure_dir_exists(self):
         if not self._credentials_path.parent.exists():
-            logger.debug("Creating credentials store parent directory: {}", self._credentials_path.parent)
+            logger.debug("Creating credentials store parent directory: %s", self._credentials_path.parent)
             self._credentials_path.parent.mkdir(parents=True, mode=0o755)

--- a/credentials.py
+++ b/credentials.py
@@ -62,13 +62,13 @@ class CredentialsStore:
 
     def _write(self, credentials):
         self._ensure_file_exists()
-        with open(self._credentials_path, 'w') as token_file:
+        with open(str(self._credentials_path), 'w') as token_file:
             contents = "\n".join(["\t".join(item) for item in credentials.items()])
             token_file.write(contents)
 
     def _read(self):
         self._ensure_file_exists()
-        with open(self._credentials_path) as token_file:
+        with open(str(self._credentials_path)) as token_file:
             credentials = dict()
             for line in token_file:
                 try:

--- a/credentials.py
+++ b/credentials.py
@@ -1,0 +1,92 @@
+# coding=utf-8
+"""
+credentials contains the CredentialsStore class, which responsible for persisting access tokens to disk.
+"""
+
+import logging
+from pathlib import Path
+from typing import Mapping
+
+DEFAULT_CREDENTIALS_PATH = Path.home() / '.bwapi' / "credentials.txt"
+
+logger = logging.getLogger("bwapi")
+
+
+class CredentialsStore:
+    """
+    CredentialsStore is responsible for persisting access tokens to disk.
+    """
+
+    _credentials_path: Path
+
+    def __init__(self, credentials_path=DEFAULT_CREDENTIALS_PATH):
+        """
+        Create a new CredentialsStore
+
+        :param credentials_path: Path to the credentials file
+        """
+        self._credentials_path = credentials_path
+
+    def __getitem__(self, username: str) -> str:
+        """ Get self[username] """
+        user_tokens = self._read()
+        return user_tokens[username.lower()]
+
+    def __setitem__(self, username: str, token: str):
+        """ Set self[username] to access token. """
+        credentials = self._read()
+        if username.lower() in credentials:
+            if credentials[username.lower()] == token:
+                return
+            else:
+                logger.debug("Overwriting access token for user: {}", username)
+        else:
+            logger.debug("Writing access token for user: {}", username)
+        credentials[username.lower()] = token
+        self._write(credentials)
+
+    def __delitem__(self, username):
+        """ Delete self[username]. """
+        credentials = self._read()
+        if username.lower() in credentials:
+            logger.debug("Deleting access token for user: {}", username)
+            del credentials[username.lower()]
+            self._write(credentials)
+
+    def __iter__(self):
+        """ Implement iter(self). """
+        credentials = self._read()
+        yield from credentials.items()
+
+    def __len__(self):
+        return len(self._read())
+
+    def _write(self, credentials: Mapping[str, str]):
+        self._ensure_file_exists()
+        with open(self._credentials_path, 'w') as token_file:
+            contents = "\n".join(["\t".join(item) for item in credentials.items()])
+            token_file.write(contents)
+
+    def _read(self) -> Mapping[str, str]:
+        self._ensure_file_exists()
+        with open(self._credentials_path) as token_file:
+            credentials = dict()
+            for line in token_file:
+                try:
+                    user, token = line.split()
+                except ValueError:
+                    logger.warning("Ignoring corrupted credentials line: \"{}\"", line)
+                    pass
+                credentials[user.lower()] = token
+            return credentials
+
+    def _ensure_file_exists(self):
+        self._ensure_dir_exists()
+        if not self._credentials_path.exists():
+            logger.debug("Creating credentials store: {}", self._credentials_path)
+            self._credentials_path.touch(mode=0o600)
+
+    def _ensure_dir_exists(self):
+        if not self._credentials_path.parent.exists():
+            logger.debug("Creating credentials store parent directory: {}", self._credentials_path.parent)
+            self._credentials_path.parent.mkdir(parents=True, mode=0o755)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
         'License :: OSI Approved :: MIT License',
 
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/test/test_credentials.py
+++ b/test/test_credentials.py
@@ -10,91 +10,101 @@ ACCESS_TOKEN = "00000000-0000-0000-0000-000000000000"
 
 class TestCredentialsStore(unittest.TestCase):
 
-    def setUp(self):
-        self.credentials_dir = Path(tempfile.NamedTemporaryFile().name)
-        self.credentials_file = self.credentials_dir / 'tokens.txt'
-        self.credentials_store = CredentialsStore(credentials_path=self.credentials_file)
+    def with_credential_store(function):
+        def wrapper(self):
+            with tempfile.TemporaryDirectory() as temp_dir:
+                token_path = Path(temp_dir) / 'tokens.txt'
+                store = CredentialsStore(credentials_path=token_path)
+                function(self, store)
+        return wrapper
 
-    def tearDown(self):
-        if self.credentials_file.exists():
-            self.credentials_file.unlink()
-        if self.credentials_dir.exists():
-            self.credentials_dir.rmdir()
+    @with_credential_store
+    def test_file_created_on_read(self, store):
+        self.assertFalse(store._credentials_path.exists())
 
-    def test_file_created_on_read(self):
-        self.assertFalse(self.credentials_file.exists())
+        _ = [c for c in store]
 
-        _ = [c for c in self.credentials_store]
+        self.assertTrue(store._credentials_path.exists())
 
-        self.assertTrue(self.credentials_file.exists())
+    @with_credential_store
+    def test_file_created_on_write(self, store):
+        self.assertFalse(store._credentials_path.exists())
 
-    def test_file_created_on_write(self):
-        self.assertFalse(self.credentials_file.exists())
+        store["example@example.com"] = ACCESS_TOKEN
 
-        self.credentials_store["example@example.com"] = ACCESS_TOKEN
+        self.assertTrue(store._credentials_path.exists())
 
-        self.assertTrue(self.credentials_file.exists())
+    @with_credential_store
+    def test_store(self, store):
+        self.assertEqual(len(store), 0)
 
-    def test_store(self):
-        self.assertEqual(len(self.credentials_store), 0)
+        store["example@example.com"] = ACCESS_TOKEN
 
-        self.credentials_store["example@example.com"] = ACCESS_TOKEN
+        self.assertEqual(store["example@example.com"], ACCESS_TOKEN)
+        self.assertEqual(len(store), 1)
 
-        self.assertEqual(self.credentials_store["example@example.com"], ACCESS_TOKEN)
-        self.assertEqual(len(self.credentials_store), 1)
+    @with_credential_store
+    def test_store_multiple(self, store):
+        self.assertEqual(len(store), 0)
 
-    def test_store_multiple(self):
-        self.assertEqual(len(self.credentials_store), 0)
+        store["example@example.com"] = "10000000-0000-0000-0000-000000000000"
+        store["another-example@example.com"] = "20000000-0000-0000-0000-000000000000"
 
-        self.credentials_store["example@example.com"] = "10000000-0000-0000-0000-000000000000"
-        self.credentials_store["another-example@example.com"] = "20000000-0000-0000-0000-000000000000"
+        self.assertEqual(store["example@example.com"], "10000000-0000-0000-0000-000000000000")
+        self.assertEqual(store["another-example@example.com"], "20000000-0000-0000-0000-000000000000")
+        self.assertEqual(len(store), 2)
 
-        self.assertEqual(self.credentials_store["example@example.com"], "10000000-0000-0000-0000-000000000000")
-        self.assertEqual(self.credentials_store["another-example@example.com"], "20000000-0000-0000-0000-000000000000")
-        self.assertEqual(len(self.credentials_store), 2)
+    @with_credential_store
+    def test_store_overwrite(self, store):
+        self.assertEqual(len(store), 0)
 
-    def test_store_overwrite(self):
-        self.assertEqual(len(self.credentials_store), 0)
+        store["example@example.com"] = "10000000-0000-0000-0000-000000000000"
+        store["example@example.com"] = "20000000-0000-0000-0000-000000000000"
 
-        self.credentials_store["example@example.com"] = "10000000-0000-0000-0000-000000000000"
-        self.credentials_store["example@example.com"] = "20000000-0000-0000-0000-000000000000"
+        self.assertEqual(store["example@example.com"], "20000000-0000-0000-0000-000000000000")
 
-        self.assertEqual(self.credentials_store["example@example.com"], "20000000-0000-0000-0000-000000000000")
+    @with_credential_store
+    def test_store_same(self, store):
+        self.assertEqual(len(store), 0)
 
-    def test_store_same(self):
-        self.assertEqual(len(self.credentials_store), 0)
+        store["example@example.com"] = ACCESS_TOKEN
+        store["example@example.com"] = ACCESS_TOKEN
 
-        self.credentials_store["example@example.com"] = ACCESS_TOKEN
-        self.credentials_store["example@example.com"] = ACCESS_TOKEN
+        self.assertEqual(store["example@example.com"], ACCESS_TOKEN)
 
-        self.assertEqual(self.credentials_store["example@example.com"], ACCESS_TOKEN)
+    @with_credential_store
+    def test_store_case_insensitive(self, store):
+        store["example@example.com"] = ACCESS_TOKEN
+        store["EXAMPLE@EXAMPLE.COM"] = ACCESS_TOKEN
+        store["eXaMpLe@ExAmPlE.cOm"] = ACCESS_TOKEN
+        self.assertEqual(len(store), 1)
 
-    def test_store_case_insensitive(self):
-        self.credentials_store["example@example.com"] = ACCESS_TOKEN
-        self.credentials_store["EXAMPLE@EXAMPLE.COM"] = ACCESS_TOKEN
-        self.credentials_store["eXaMpLe@ExAmPlE.cOm"] = ACCESS_TOKEN
-        self.assertEqual(len(self.credentials_store), 1)
+    @with_credential_store
+    def test_store_lower(self, store):
+        store["example@example.com"] = ACCESS_TOKEN
+        self.assertEqual(store["example@example.com"], ACCESS_TOKEN)
 
-    def test_store_lower(self):
-        self.credentials_store["example@example.com"] = ACCESS_TOKEN
-        self.assertEqual(self.credentials_store["example@example.com"], ACCESS_TOKEN)
+    @with_credential_store
+    def test_store_upper(self, store):
+        store["EXAMPLE@EXAMPLE.COM"] = ACCESS_TOKEN
+        self.assertEqual(store["example@example.com"], ACCESS_TOKEN)
 
-    def test_store_upper(self):
-        self.credentials_store["EXAMPLE@EXAMPLE.COM"] = ACCESS_TOKEN
-        self.assertEqual(self.credentials_store["example@example.com"], ACCESS_TOKEN)
+    @with_credential_store
+    def test_store_mixed(self, store):
+        store["eXaMpLe@ExAmPlE.cOm"] = ACCESS_TOKEN
+        self.assertEqual(store["example@example.com"], ACCESS_TOKEN)
 
-    def test_store_mixed(self):
-        self.credentials_store["eXaMpLe@ExAmPlE.cOm"] = ACCESS_TOKEN
-        self.assertEqual(self.credentials_store["example@example.com"], ACCESS_TOKEN)
+    @with_credential_store
+    def test_get_lower(self, store):
+        store["example@example.com"] = ACCESS_TOKEN
+        self.assertEqual(store["example@example.com"], ACCESS_TOKEN)
 
-    def test_get_lower(self):
-        self.credentials_store["example@example.com"] = ACCESS_TOKEN
-        self.assertEqual(self.credentials_store["example@example.com"], ACCESS_TOKEN)
+    @with_credential_store
+    def test_get_upper(self, store):
+        store["example@example.com"] = ACCESS_TOKEN
+        self.assertEqual(store["EXAMPLE@EXAMPLE.COM"], ACCESS_TOKEN)
 
-    def test_get_upper(self):
-        self.credentials_store["example@example.com"] = ACCESS_TOKEN
-        self.assertEqual(self.credentials_store["EXAMPLE@EXAMPLE.COM"], ACCESS_TOKEN)
-
-    def test_get_mixed(self):
-        self.credentials_store["example@example.com"] = ACCESS_TOKEN
-        self.assertEqual(self.credentials_store["eXaMpLe@ExAmPlE.cOm"], ACCESS_TOKEN)
+    @with_credential_store
+    def test_get_mixed(self, store):
+        store["example@example.com"] = ACCESS_TOKEN
+        self.assertEqual(store["eXaMpLe@ExAmPlE.cOm"], ACCESS_TOKEN)

--- a/test/test_credentials.py
+++ b/test/test_credentials.py
@@ -1,0 +1,100 @@
+# coding=utf-8
+import tempfile
+import unittest
+from pathlib import Path
+
+from credentials import CredentialsStore
+
+ACCESS_TOKEN = "00000000-0000-0000-0000-000000000000"
+
+
+class TestCredentialsStore(unittest.TestCase):
+
+    def setUp(self):
+        self.credentials_dir = Path(tempfile.NamedTemporaryFile().name)
+        self.credentials_file = self.credentials_dir / 'tokens.txt'
+        self.credentials_store = CredentialsStore(credentials_path=self.credentials_file)
+
+    def tearDown(self):
+        if self.credentials_file.exists():
+            self.credentials_file.unlink()
+        if self.credentials_dir.exists():
+            self.credentials_dir.rmdir()
+
+    def test_file_created_on_read(self):
+        self.assertFalse(self.credentials_file.exists())
+
+        _ = [c for c in self.credentials_store]
+
+        self.assertTrue(self.credentials_file.exists())
+
+    def test_file_created_on_write(self):
+        self.assertFalse(self.credentials_file.exists())
+
+        self.credentials_store["example@example.com"] = ACCESS_TOKEN
+
+        self.assertTrue(self.credentials_file.exists())
+
+    def test_store(self):
+        self.assertEqual(len(self.credentials_store), 0)
+
+        self.credentials_store["example@example.com"] = ACCESS_TOKEN
+
+        self.assertEqual(self.credentials_store["example@example.com"], ACCESS_TOKEN)
+        self.assertEqual(len(self.credentials_store), 1)
+
+    def test_store_multiple(self):
+        self.assertEqual(len(self.credentials_store), 0)
+
+        self.credentials_store["example@example.com"] = "10000000-0000-0000-0000-000000000000"
+        self.credentials_store["another-example@example.com"] = "20000000-0000-0000-0000-000000000000"
+
+        self.assertEqual(self.credentials_store["example@example.com"], "10000000-0000-0000-0000-000000000000")
+        self.assertEqual(self.credentials_store["another-example@example.com"], "20000000-0000-0000-0000-000000000000")
+        self.assertEqual(len(self.credentials_store), 2)
+
+    def test_store_overwrite(self):
+        self.assertEqual(len(self.credentials_store), 0)
+
+        self.credentials_store["example@example.com"] = "10000000-0000-0000-0000-000000000000"
+        self.credentials_store["example@example.com"] = "20000000-0000-0000-0000-000000000000"
+
+        self.assertEqual(self.credentials_store["example@example.com"], "20000000-0000-0000-0000-000000000000")
+
+    def test_store_same(self):
+        self.assertEqual(len(self.credentials_store), 0)
+
+        self.credentials_store["example@example.com"] = ACCESS_TOKEN
+        self.credentials_store["example@example.com"] = ACCESS_TOKEN
+
+        self.assertEqual(self.credentials_store["example@example.com"], ACCESS_TOKEN)
+
+    def test_store_case_insensitive(self):
+        self.credentials_store["example@example.com"] = ACCESS_TOKEN
+        self.credentials_store["EXAMPLE@EXAMPLE.COM"] = ACCESS_TOKEN
+        self.credentials_store["eXaMpLe@ExAmPlE.cOm"] = ACCESS_TOKEN
+        self.assertEqual(len(self.credentials_store), 1)
+
+    def test_store_lower(self):
+        self.credentials_store["example@example.com"] = ACCESS_TOKEN
+        self.assertEqual(self.credentials_store["example@example.com"], ACCESS_TOKEN)
+
+    def test_store_upper(self):
+        self.credentials_store["EXAMPLE@EXAMPLE.COM"] = ACCESS_TOKEN
+        self.assertEqual(self.credentials_store["example@example.com"], ACCESS_TOKEN)
+
+    def test_store_mixed(self):
+        self.credentials_store["eXaMpLe@ExAmPlE.cOm"] = ACCESS_TOKEN
+        self.assertEqual(self.credentials_store["example@example.com"], ACCESS_TOKEN)
+
+    def test_get_lower(self):
+        self.credentials_store["example@example.com"] = ACCESS_TOKEN
+        self.assertEqual(self.credentials_store["example@example.com"], ACCESS_TOKEN)
+
+    def test_get_upper(self):
+        self.credentials_store["example@example.com"] = ACCESS_TOKEN
+        self.assertEqual(self.credentials_store["EXAMPLE@EXAMPLE.COM"], ACCESS_TOKEN)
+
+    def test_get_mixed(self):
+        self.credentials_store["example@example.com"] = ACCESS_TOKEN
+        self.assertEqual(self.credentials_store["eXaMpLe@ExAmPlE.cOm"], ACCESS_TOKEN)


### PR DESCRIPTION
Reworked the authentication flow so passwords are no longer required in code. The previous flow still works, so these changes should be backwards compatible, but now we have new (and hopefully better) options. 

The new flow is roughly this:
1. Run `authenticate.py` providing your username and password. This will store username and access token in `~/.bwapi/tokens.txt` (by default).
   - When running `authenticate.py` one can provide username and password as arguments, but it will prompt you if you omit anything.
   - The `tokens.txt` path can be changed, but I recommend you have a single global file, rather in the PWD as was the previous default.
  - One can authenticate as many users as you want this way. 
   - Alternatively, call `authenticate(...)` function programmatically to achieve the same thing.
2. Instantiate `BWProject` with _just_ your username.
   - Alternatively, provide an access token too - this method is primarily intended for injecting CI secrets. 

Why is this better? Firstly it keeps passwords and access tokens out of code. Passwords are only used once to retrieve an access token, and then the access tokens are store relatively security (chmod 600) in home your directory. Since passwords are never used in code, and the access tokens are stored in the working directory, it reduces the likelihood of the wrong things being committed to version control. Secondly, it allows access tokens to be generated and injected without writing custom code, to facilitate CIs and ATS. 

There's more to do here, but this seems like a good place to stop. Further changes may start to break backwards compatibility. The following additional changes are ~planned~ aspired towards:

- I originally added support for file locking to deal with https://github.com/BrandwatchLtd/api_sdk/issues/54 - but dropped it because it was bloating the PR, and there were some irritating edge cases to work out.
 -  Password option should be dropped from `BWUser` constructor. 

