### PR TITLE
Issue Deprecation Warning on Package Import

### DIFF
--- a/src/bwapi/__init__.py
+++ b/src/bwapi/__init__.py
@@ -1,3 +1,11 @@
 """Top-level package for bwapi."""
+from warnings import warn
 
 __version__ = "4.1.0"
+
+warn(
+    "The bwapi package is deprecated. Please use 'bcr-api' instead: "
+    "https://github.com/BrandwatchLtd/bcr-api",
+    DeprecationWarning,
+    stacklevel=2,
+)


### PR DESCRIPTION
This will let users know the package is deprecated when they import it.

Also, if we publish this it will update [the page on PyPI](https://pypi.org/project/bwapi/), which doesn't currently show the package as deprecated.